### PR TITLE
To simplify unit/integration testing allow setting of values from os environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: python
 dist: trusty
 sudo: true
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7-dev"
+
+jobs:
+  - { language: python, python: "2.6", dist: "trusty", sudo: true }
+  - { language: python, python: "2.7", dist: "trusty", sudo: true }
+  - { language: python, python: "3.3", dist: "trusty", sudo: true }
+  - { language: python, python: "3.4", dist: "trusty", sudo: true }
+  - { language: python, python: "3.5", dist: "trusty", sudo: true }
+  - { language: python, python: "3.6", dist: "trusty", sudo: true }
+  - { language: python, python: "3.7", dist: "xenial", sudo: true }
+  - { language: python, python: "3.8", dist: "xenial", sudo: true }
+  
 # command to install dependencies
 install:
   - "virtualenv venv --no-site-packages"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: python
-dist: trusty
-sudo: true
 
 jobs:
   - { language: python, python: "2.6", dist: "trusty", sudo: true }
@@ -11,7 +9,7 @@ jobs:
   - { language: python, python: "3.6", dist: "trusty", sudo: true }
   - { language: python, python: "3.7", dist: "xenial", sudo: true }
   - { language: python, python: "3.8", dist: "xenial", sudo: true }
-  
+
 # command to install dependencies
 install:
   - "virtualenv venv --no-site-packages"
@@ -43,7 +41,6 @@ deploy:
 notifications:
   email:
     recipients:
-      - developer@configcat.com      
+      - developer@configcat.com
     on_success: never
     on_failure: always
-

--- a/configcatclienttests/test_configcatclient.py
+++ b/configcatclienttests/test_configcatclient.py
@@ -1,5 +1,6 @@
 import logging
 import unittest
+from mock import patch
 
 from configcatclient import ConfigCatClientException
 from configcatclient.configcatclient import ConfigCatClient
@@ -53,6 +54,21 @@ class ConfigCatClientTests(unittest.TestCase):
                          set(client.get_all_keys()))
         client.stop()
 
+    @patch('configcatclient.configcatclient.os.environ', {'CONFIGCAT_VALUE_test': 'ON', 'CONFIGCAT_VALUE_F': 'FALSE'})
+    def test_env_override_with_allow(self):
+        client = ConfigCatClient('test', 0, 0, None, 0, config_cache_class=ConfigCacheMock, allow_environment_override=True)
+        self.assertEqual(True, client.get_value('test', None))
+        self.assertEqual(False, client.get_value('F', None))
+        self.assertEqual('Y', client.get_value('X', 'Y'))
+        client.stop()
+
+    @patch('os.environ', {'CONFIGCAT_VALUE_test': 'ON', 'CONFIGCAT_VALUE_F': 'FALSE'})
+    def test_env_override_without_allow(self):
+        client = ConfigCatClient('test', 0, 0, None, 0, config_cache_class=ConfigCacheMock)
+        self.assertEqual(None, client.get_value('test', None))
+        self.assertEqual(False, client.get_value('F', False))
+        self.assertEqual('Y', client.get_value('X', 'Y'))
+        client.stop()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
During integration test I find it very helpful to be able to set one specific flag to a specific value (multiple values over the course of the whole test suite) to test both old and new behavior without changing things for other users in the normal staging/production environments.

with this patch a configcatclient, who was passed the new init arg `allow_environment_override` (so the default behavior does not change) will return true if there exists and env var with the same name as the key, prefix with `CONFIGCAT_VALUE_` whose value is one of `1`, `enable`, `enabled`, `on`, `true`, `yes`. any other value will return false. if the env var is not set at all (which is different from being set to `""`) then we call configcat directly.