### PR TITLE
call the is_fetched function in lazy loading cache policy

### DIFF
--- a/configcatclient/lazyloadingcachepolicy.py
+++ b/configcatclient/lazyloadingcachepolicy.py
@@ -44,7 +44,7 @@ class LazyLoadingCachePolicy(CachePolicy):
     def force_refresh(self):
         try:
             configuration_response = self._config_fetcher.get_configuration_json()
-            if configuration_response.is_fetched:
+            if configuration_response.is_fetched():
                 configuration = configuration_response.json()
                 try:
                     self._lock.acquire_write()

--- a/configcatclienttests/test_lazyloadingcachepolicy.py
+++ b/configcatclienttests/test_lazyloadingcachepolicy.py
@@ -69,7 +69,7 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
         not_modified_response = mock.MagicMock()
         not_modified_response.status_code = 304
         not_modified_response.json.side_effect = ValueError("this response contains no body")
-        config_fetcher.get_configuration_json.return_value = successful_response
+        config_fetcher.get_configuration_json.return_value = FetchResponse(successful_response)
         config_cache = InMemoryConfigCache()
         cache_policy = LazyLoadingCachePolicy(config_fetcher, config_cache, 160)
 
@@ -79,13 +79,14 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
             value = cache_policy.get()
             self.assertEqual(mock_datetime.datetime.utcnow.call_count, 2)
             self.assertEqual(value, TEST_JSON)
-            config_fetcher.get_configuration_json.return_value = not_modified_response
+            self.assertEqual(successful_response.json.call_count, 1)
+            config_fetcher.get_configuration_json.return_value = FetchResponse(not_modified_response)
             cache_policy.force_refresh()
             self.assertEqual(value, TEST_JSON)
             self.assertEqual(config_fetcher.get_configuration_json.call_count, 2)
             # this indicates that is_fetched() was correctly called and
             # the setting of the new last updated didn't occur
-            self.assertEqual(mock_datetime.datetime.utcnow.call_count, 2)
+            self.assertEqual(not_modified_response.json.call_count, 0)
         cache_policy.stop()
 
     def test_http_error(self):

--- a/configcatclienttests/test_lazyloadingcachepolicy.py
+++ b/configcatclienttests/test_lazyloadingcachepolicy.py
@@ -1,11 +1,14 @@
 import logging
 import unittest
 import time
+import datetime
 from requests import HTTPError
+import mock
 
 from configcatclient.configcache import InMemoryConfigCache
 from configcatclient.lazyloadingcachepolicy import LazyLoadingCachePolicy
 from configcatclienttests.mocks import ConfigFetcherMock, ConfigFetcherWithErrorMock, TEST_JSON
+from configcatclient.configfetcher import FetchResponse
 
 logging.basicConfig()
 
@@ -56,6 +59,36 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
         value = cache_policy.get()
         self.assertEqual(value, TEST_JSON)
         self.assertEqual(config_fetcher.get_call_count, 2)
+        cache_policy.stop()
+
+    def test_force_refresh_honours_304(self):
+        config_fetcher = mock.MagicMock()
+        successful_response = mock.MagicMock()
+        successful_response.status_code = 200
+        successful_response.json.return_value = TEST_JSON
+        not_modified_response = mock.MagicMock()
+        not_modified_response.status_code = 304
+        not_modified_response.json.side_effect = ValueError("this response contains no body")
+        config_fetcher.get_configuration_json.side_effect = {
+            FetchResponse(successful_response),
+            FetchResponse(not_modified_response)
+        }
+        config_cache = InMemoryConfigCache()
+        cache_policy = LazyLoadingCachePolicy(config_fetcher, config_cache, 160)
+
+        # Get value from Config Store, which indicates a config_fetcher call
+        with mock.patch('configcatclient.lazyloadingcachepolicy.datetime') as mock_datetime:
+            mock_datetime.datetime.utcnow.return_value = datetime.datetime(2020, 5, 20, 0, 0, 0)
+            value = cache_policy.get()
+            self.assertEqual(value, TEST_JSON)
+            self.assertEqual(mock_datetime.datetime.utcnow.call_count, 2)
+
+            cache_policy.force_refresh()
+            self.assertEqual(value, TEST_JSON)
+            self.assertEqual(config_fetcher.get_configuration_json.call_count, 2)
+            # this indicates that is_fetched() was correctly called and
+            # the setting of the new last updated didn't occur
+            self.assertEqual(mock_datetime.datetime.utcnow.call_count, 2)
         cache_policy.stop()
 
     def test_http_error(self):

--- a/configcatclienttests/test_lazyloadingcachepolicy.py
+++ b/configcatclienttests/test_lazyloadingcachepolicy.py
@@ -61,7 +61,7 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
         self.assertEqual(config_fetcher.get_call_count, 2)
         cache_policy.stop()
 
-    def test_force_refresh_not_modified_cnofig(self):
+    def test_force_refresh_not_modified_config(self):
         config_fetcher = mock.MagicMock()
         successful_fetch_response = mock.MagicMock()
         successful_fetch_response.is_fetched.return_value = True


### PR DESCRIPTION
The is_fetched function was being used as a property with python
truthiness which would always evaluate as true, which in turn
would cause an exception to be logged unnecessarily.