### PR TITLE
fix when multiple threads each hit the write lock

### DIFF
--- a/configcatclient/lazyloadingcachepolicy.py
+++ b/configcatclient/lazyloadingcachepolicy.py
@@ -32,7 +32,15 @@ class LazyLoadingCachePolicy(CachePolicy):
         finally:
             self._lock.release_read()
 
-        self.force_refresh()
+        try:
+            self._lock.acquire_write()
+            # If while waiting to acquire the write lock another
+            # thread has updated the content, then don't bother requesting
+            # to the server to minimise time.
+            if self._last_updated is None or self._last_updated + self._cache_time_to_live <= datetime.datetime.utcnow():
+                self.force_refresh()
+        finally:
+            self._lock.release_write()
 
         try:
             self._lock.acquire_read()
@@ -43,12 +51,6 @@ class LazyLoadingCachePolicy(CachePolicy):
 
     def force_refresh(self):
         try:
-            self._lock.acquire_write()
-            # If while waiting to acquire the write lock another
-            # thread has updated the content, then don't bother requesting
-            # to the server to minimise time.
-            if self._last_updated is not None and self._last_updated + self._cache_time_to_live >= datetime.datetime.utcnow():
-                return
             configuration_response = self._config_fetcher.get_configuration_json()
             # set _last_updated regardless of whether the cache is updated
             # or whether a 304 not modified has been sent back as the content
@@ -63,8 +65,6 @@ class LazyLoadingCachePolicy(CachePolicy):
                       ' Received unexpected response: %s' % str(e.response))
         except:
             log.exception(sys.exc_info()[0])
-        finally:
-            self._lock.release_write()
 
 
     def stop(self):

--- a/configcatclienttests/test_lazyloadingcachepolicy.py
+++ b/configcatclienttests/test_lazyloadingcachepolicy.py
@@ -54,12 +54,16 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
         self.assertEqual(value, TEST_JSON)
         self.assertEqual(config_fetcher.get_call_count, 1)
 
-        # Get value from Config Store, which indicates a config_fetcher call after cache invalidation
-        cache_policy.force_refresh()
-        value = cache_policy.get()
-        self.assertEqual(value, TEST_JSON)
-        self.assertEqual(config_fetcher.get_call_count, 2)
-        cache_policy.stop()
+        with mock.patch('configcatclient.lazyloadingcachepolicy.datetime') as mock_datetime:
+            # assume 160 seconds has elapsed since the last call enough to do a 
+            # force refresh
+            mock_datetime.datetime.utcnow.return_value = cache_policy._last_updated + datetime.timedelta(seconds=161)
+            # Get value from Config Store, which indicates a config_fetcher call after cache invalidation
+            cache_policy.force_refresh()
+            value = cache_policy.get()
+            self.assertEqual(value, TEST_JSON)
+            self.assertEqual(config_fetcher.get_call_count, 2)
+            cache_policy.stop()
 
     def test_force_refresh_not_modified_config(self):
         config_fetcher = mock.MagicMock()
@@ -87,10 +91,36 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
             # this indicates that is_fetched() was correctly called and
             # the setting of the new last updated didn't occur
             self.assertEqual(not_modified_fetch_response.json.call_count, 0)
-            self.assertEqual(mock_datetime.datetime.utcnow.call_count, 3)
+            self.assertEqual(mock_datetime.datetime.utcnow.call_count, 4)
             # last updated should still be set in the case of a 304
             self.assertEqual(cache_policy._last_updated, new_time)
         cache_policy.stop()
+
+    def test_force_refresh_skips_hitting_api_after_update(self):
+        config_fetcher = mock.MagicMock()
+        successful_fetch_response = mock.MagicMock()
+        successful_fetch_response.is_fetched.return_value = True
+        successful_fetch_response.json.return_value = TEST_JSON
+        config_fetcher.get_configuration_json.return_value = successful_fetch_response
+        config_cache = InMemoryConfigCache()
+        cache_policy = LazyLoadingCachePolicy(config_fetcher, config_cache, 160)
+
+        # Get value from Config Store, which indicates a config_fetcher call
+        with mock.patch('configcatclient.lazyloadingcachepolicy.datetime') as mock_datetime:
+            now = datetime.datetime(2020, 5, 20, 0, 0, 0)
+            mock_datetime.datetime.utcnow.return_value = now
+            self.assertIsNone(cache_policy._last_updated)
+            cache_policy.force_refresh()
+            self.assertEqual(config_fetcher.get_configuration_json.call_count, 1)
+            # when the cache timeout is still within the limit skip any network
+            # requests, as this could be that multiple threads have attempted
+            # to acquire the lock at the same time, but only really one needs to update
+            cache_policy._last_updated = now - datetime.timedelta(seconds=159)
+            cache_policy.force_refresh()
+            self.assertEqual(config_fetcher.get_configuration_json.call_count, 1)
+            cache_policy._last_updated = now - datetime.timedelta(seconds=161)
+            cache_policy.force_refresh()
+            self.assertEqual(config_fetcher.get_configuration_json.call_count, 2)
 
     def test_http_error(self):
         config_fetcher = ConfigFetcherWithErrorMock(HTTPError("error"))


### PR DESCRIPTION
This fixes when you have multiple threads that hit the
write lock at the same time, where only 1 thread actually
needs to succeed and update the cached flag content.
This reduces the network load and number of requests to
configcat servers.
This was noticed when multiple threads all were requested
at the same time, each thread would still do a network request to configcat.