### PR TITLE
fix issue with installation of configcatclient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-from configcatclient.version import CONFIGCATCLIENT_VERSION
 
 
 def parse_requirements(filename):
@@ -7,7 +6,7 @@ def parse_requirements(filename):
     return [line for line in lines if line]
 
 
-configcatclient_version = CONFIGCATCLIENT_VERSION
+configcatclient_version = '4.0.2'
 
 requirements = parse_requirements('requirements.txt')
 


### PR DESCRIPTION
The issue here is when the version was being imported from
the package itself, it would effectively make all the runtime
dependencies a build time dependency. So installation from pypi
or using a pip VCS url would make the build require the semver and
requests at installation/build time.
This would still occur with 4.0.2 from pypi as it is a tarball
and not a python egg or wheel, which would only ship the artifacts
and not require the installation client to do the build.