### PR TITLE
Force fetch config when cache empty

### DIFF
--- a/configcatclient/configfetcher.py
+++ b/configcatclient/configfetcher.py
@@ -14,7 +14,6 @@ log = logging.getLogger(sys.modules[__name__].__name__)
 
 
 class FetchResponse(object):
-
     def __init__(self, response):
         self._response = response
 
@@ -38,7 +37,6 @@ class FetchResponse(object):
 
 
 class ConfigFetcher(object):
-
     def __init__(self, sdk_key, mode, base_url=None, proxies=None, proxy_auth=None):
         self._sdk_key = sdk_key
         self._proxies = proxies
@@ -52,14 +50,16 @@ class ConfigFetcher(object):
         else:
             self._base_url = BASE_URL
 
-    def get_configuration_json(self):
+    def get_configuration_json(self, force_fetch=False):
         """
         :return: Returns the FetchResponse object contains configuration json Dictionary
         """
         uri = self._base_url + '/' + BASE_PATH + self._sdk_key + BASE_EXTENSION
         headers = self._headers
-        if self._etag:
+        if self._etag and not force_fetch:
             headers['If-None-Match'] = self._etag
+        else:
+            headers['If-None-Match'] = None
 
         response = requests.get(uri, headers=headers, timeout=(10, 30),
                                 proxies=self._proxies, auth=self._proxy_auth)

--- a/configcatclient/lazyloadingcachepolicy.py
+++ b/configcatclient/lazyloadingcachepolicy.py
@@ -10,7 +10,6 @@ log = logging.getLogger(sys.modules[__name__].__name__)
 
 
 class LazyLoadingCachePolicy(CachePolicy):
-
     def __init__(self, config_fetcher, config_cache, cache_time_to_live_seconds=60):
         if cache_time_to_live_seconds < 1:
             cache_time_to_live_seconds = 1
@@ -21,12 +20,15 @@ class LazyLoadingCachePolicy(CachePolicy):
         self._last_updated = None
 
     def get(self):
+        config = None
+
         try:
             self._lock.acquire_read()
 
+            config = self._config_cache.get()
+
             utc_now = datetime.datetime.utcnow()
             if self._last_updated is not None and self._last_updated + self._cache_time_to_live > utc_now:
-                config = self._config_cache.get()
                 if config is not None:
                     return config
         finally:
@@ -37,8 +39,9 @@ class LazyLoadingCachePolicy(CachePolicy):
             # If while waiting to acquire the write lock another
             # thread has updated the content, then don't bother requesting
             # to the server to minimise time.
-            if self._last_updated is None or self._last_updated + self._cache_time_to_live <= datetime.datetime.utcnow():
-                self._force_refresh()
+            if config is None or self._last_updated is None or self._last_updated + self._cache_time_to_live <= datetime.datetime.utcnow():
+                force_fetch = not bool(config)
+                self._force_refresh(force_fetch)
         finally:
             self._lock.release_write()
 
@@ -50,15 +53,24 @@ class LazyLoadingCachePolicy(CachePolicy):
             self._lock.release_read()
 
     def force_refresh(self):
+        force_fetch = False
+
+        try:
+            self._lock.acquire_read()
+            config = self._config_cache.get()
+            force_fetch = not bool(config)
+        finally:
+            self._lock.release_read()
+
         try:
             self._lock.acquire_write()
-            self._force_refresh()
+            self._force_refresh(force_fetch)
         finally:
             self._lock.release_write()
 
-    def _force_refresh(self):
+    def _force_refresh(self, force_fetch):
         try:
-            configuration_response = self._config_fetcher.get_configuration_json()
+            configuration_response = self._config_fetcher.get_configuration_json(force_fetch)
             # set _last_updated regardless of whether the cache is updated
             # or whether a 304 not modified has been sent back as the content
             # we have hasn't been updated on the server so not need
@@ -70,9 +82,8 @@ class LazyLoadingCachePolicy(CachePolicy):
         except HTTPError as e:
             log.error('Double-check your SDK Key at https://app.configcat.com/sdkkey.'
                       ' Received unexpected response: %s' % str(e.response))
-        except:
+        except Exception:
             log.exception(sys.exc_info()[0])
-
 
     def stop(self):
         pass

--- a/configcatclient/manualpollingcachepolicy.py
+++ b/configcatclient/manualpollingcachepolicy.py
@@ -9,7 +9,6 @@ log = logging.getLogger(sys.modules[__name__].__name__)
 
 
 class ManualPollingCachePolicy(CachePolicy):
-
     def __init__(self, config_fetcher, config_cache):
         self._config_fetcher = config_fetcher
         self._config_cache = config_cache
@@ -25,8 +24,17 @@ class ManualPollingCachePolicy(CachePolicy):
             self._lock.release_read()
 
     def force_refresh(self):
+        force_fetch = False
+
         try:
-            configuration_response = self._config_fetcher.get_configuration_json()
+            self._lock.acquire_read()
+            config = self._config_cache.get()
+            force_fetch = not bool(config)
+        finally:
+            self._lock.release_read()
+
+        try:
+            configuration_response = self._config_fetcher.get_configuration_json(force_fetch)
             if configuration_response.is_fetched():
                 configuration = configuration_response.json()
                 try:
@@ -38,7 +46,7 @@ class ManualPollingCachePolicy(CachePolicy):
         except HTTPError as e:
             log.error('Double-check your SDK Key at https://app.configcat.com/sdkkey.'
                       ' Received unexpected response: [%s]' % str(e.response))
-        except:
+        except Exception:
             log.exception(sys.exc_info()[0])
 
     def stop(self):

--- a/configcatclienttests/mocks.py
+++ b/configcatclienttests/mocks.py
@@ -1,5 +1,6 @@
 import json
 import time
+
 try:
     from unittest.mock import Mock
 except ImportError:
@@ -29,12 +30,11 @@ TEST_OBJECT = json.loads(
 
 
 class ConfigFetcherMock(ConfigFetcher):
-
     def __init__(self):
         self._call_count = 0
         self._configuration = TEST_JSON
 
-    def get_configuration_json(self):
+    def get_configuration_json(self, force_fetch=False):
         self._call_count = self._call_count + 1
         response_mock = Mock()
         response_mock.status_code = 200
@@ -50,20 +50,18 @@ class ConfigFetcherMock(ConfigFetcher):
 
 
 class ConfigFetcherWithErrorMock(ConfigFetcher):
-
     def __init__(self, exception):
         self._exception = exception
 
-    def get_configuration_json(self):
+    def get_configuration_json(self, force_fetch=False):
         raise self._exception
 
 
 class ConfigFetcherWaitMock(ConfigFetcher):
-
     def __init__(self, wait_seconds):
         self._wait_seconds = wait_seconds
 
-    def get_configuration_json(self):
+    def get_configuration_json(self, force_fetch=False):
         time.sleep(self._wait_seconds)
         response_mock = Mock()
         response_mock.status_code = 200
@@ -72,11 +70,10 @@ class ConfigFetcherWaitMock(ConfigFetcher):
 
 
 class ConfigFetcherCountMock(ConfigFetcher):
-
     def __init__(self):
         self._value = 0
 
-    def get_configuration_json(self):
+    def get_configuration_json(self, force_fetch=False):
         self._value += 10
         response_mock = Mock()
         response_mock.status_code = 200
@@ -85,7 +82,6 @@ class ConfigFetcherCountMock(ConfigFetcher):
 
 
 class ConfigCacheMock(ConfigCache):
-
     def get(self):
         return TEST_OBJECT
 

--- a/configcatclienttests/mocks.py
+++ b/configcatclienttests/mocks.py
@@ -32,10 +32,13 @@ TEST_OBJECT = json.loads(
 class ConfigFetcherMock(ConfigFetcher):
     def __init__(self):
         self._call_count = 0
+        self._force_fetch_count = 0
         self._configuration = TEST_JSON
 
     def get_configuration_json(self, force_fetch=False):
-        self._call_count = self._call_count + 1
+        self._call_count += 1
+        if force_fetch:
+            self._force_fetch_count += 1
         response_mock = Mock()
         response_mock.status_code = 200
         response_mock.json.return_value = self._configuration
@@ -47,6 +50,10 @@ class ConfigFetcherMock(ConfigFetcher):
     @property
     def get_call_count(self):
         return self._call_count
+
+    @property
+    def get_force_fetch_count(self):
+        return self._force_fetch_count
 
 
 class ConfigFetcherWithErrorMock(ConfigFetcher):

--- a/configcatclienttests/test_autopollingcachepolicy.py
+++ b/configcatclienttests/test_autopollingcachepolicy.py
@@ -137,6 +137,27 @@ class AutoPollingCachePolicyTests(unittest.TestCase):
         self.assertEqual(call_counter.get_call_count, 2)
         cache_policy.stop()
 
+    def test_refetch_config(self):
+        config_fetcher = ConfigFetcherMock()
+        config_cache = InMemoryConfigCache()
+        cache_policy = AutoPollingCachePolicy(config_fetcher, config_cache, 2, 1, None)
+        time.sleep(1.5)
+        config = cache_policy.get()
+        self.assertEqual(config, TEST_JSON)
+
+        try:
+            # Clear the cache
+            cache_policy._lock.acquire_write()
+            cache_policy._config_cache.set(None)
+        finally:
+            cache_policy._lock.release_write()
+
+        time.sleep(1.5)
+        self.assertEqual(config_fetcher.get_call_count, 2)
+        config = cache_policy.get()
+        self.assertEqual(config, TEST_JSON)
+        cache_policy.stop()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/configcatclienttests/test_autopollingcachepolicy.py
+++ b/configcatclienttests/test_autopollingcachepolicy.py
@@ -144,6 +144,14 @@ class AutoPollingCachePolicyTests(unittest.TestCase):
         time.sleep(1.5)
         config = cache_policy.get()
         self.assertEqual(config, TEST_JSON)
+        self.assertEqual(config_fetcher.get_call_count, 1)
+        self.assertEqual(config_fetcher.get_force_fetch_count, 1)
+
+        time.sleep(1.5)
+        config = cache_policy.get()
+        self.assertEqual(config, TEST_JSON)
+        self.assertEqual(config_fetcher.get_call_count, 2)
+        self.assertEqual(config_fetcher.get_force_fetch_count, 1)
 
         try:
             # Clear the cache
@@ -153,7 +161,8 @@ class AutoPollingCachePolicyTests(unittest.TestCase):
             cache_policy._lock.release_write()
 
         time.sleep(1.5)
-        self.assertEqual(config_fetcher.get_call_count, 2)
+        self.assertEqual(config_fetcher.get_call_count, 3)
+        self.assertEqual(config_fetcher.get_force_fetch_count, 2)
         config = cache_policy.get()
         self.assertEqual(config, TEST_JSON)
         cache_policy.stop()

--- a/configcatclienttests/test_configfetcher.py
+++ b/configcatclienttests/test_configfetcher.py
@@ -1,6 +1,7 @@
 import logging
 import unittest
 import requests
+
 try:
     from unittest import mock
 except ImportError:
@@ -64,6 +65,11 @@ class ConfigFetcherTests(unittest.TestCase):
         fetch_response = fetcher.get_configuration_json()
         self.assertTrue(fetch_response.is_fetched())
         self.assertFalse(fetch_response.is_not_modified())
+
         fetch_response = fetcher.get_configuration_json()
         self.assertFalse(fetch_response.is_fetched())
         self.assertTrue(fetch_response.is_not_modified())
+
+        fetch_response = fetcher.get_configuration_json(force_fetch=True)
+        self.assertTrue(fetch_response.is_fetched())
+        self.assertFalse(fetch_response.is_not_modified())

--- a/configcatclienttests/test_lazyloadingcachepolicy.py
+++ b/configcatclienttests/test_lazyloadingcachepolicy.py
@@ -72,12 +72,19 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
     def test_force_refresh(self):
         config_fetcher = ConfigFetcherMock()
         config_cache = InMemoryConfigCache()
-        cache_policy = LazyLoadingCachePolicy(config_fetcher, config_cache, 160)
+        cache_policy = LazyLoadingCachePolicy(config_fetcher, config_cache, 1)
 
         # Get value from Config Store, which indicates a config_fetcher call
         value = cache_policy.get()
         self.assertEqual(value, TEST_JSON)
         self.assertEqual(config_fetcher.get_call_count, 1)
+        self.assertEqual(config_fetcher.get_force_fetch_count, 1)
+
+        time.sleep(1.2)
+        value = cache_policy.get()
+        self.assertEqual(value, TEST_JSON)
+        self.assertEqual(config_fetcher.get_call_count, 2)
+        self.assertEqual(config_fetcher.get_force_fetch_count, 1)
 
         try:
             # Clear the cache
@@ -88,7 +95,8 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
 
         value = cache_policy.get()
         self.assertEqual(value, TEST_JSON)
-        self.assertEqual(config_fetcher.get_call_count, 2)
+        self.assertEqual(config_fetcher.get_call_count, 3)
+        self.assertEqual(config_fetcher.get_force_fetch_count, 2)
         cache_policy.stop()
 
     def test_force_refresh_not_modified_config(self):

--- a/configcatclienttests/test_lazyloadingcachepolicy.py
+++ b/configcatclienttests/test_lazyloadingcachepolicy.py
@@ -3,7 +3,11 @@ import unittest
 import time
 import datetime
 from requests import HTTPError
-import mock
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from configcatclient.configcache import InMemoryConfigCache
 from configcatclient.lazyloadingcachepolicy import LazyLoadingCachePolicy
@@ -64,6 +68,28 @@ class LazyLoadingCachePolicyTests(unittest.TestCase):
             self.assertEqual(value, TEST_JSON)
             self.assertEqual(config_fetcher.get_call_count, 2)
             cache_policy.stop()
+
+    def test_force_refresh(self):
+        config_fetcher = ConfigFetcherMock()
+        config_cache = InMemoryConfigCache()
+        cache_policy = LazyLoadingCachePolicy(config_fetcher, config_cache, 160)
+
+        # Get value from Config Store, which indicates a config_fetcher call
+        value = cache_policy.get()
+        self.assertEqual(value, TEST_JSON)
+        self.assertEqual(config_fetcher.get_call_count, 1)
+
+        try:
+            # Clear the cache
+            cache_policy._lock.acquire_write()
+            cache_policy._config_cache.set(None)
+        finally:
+            cache_policy._lock.release_write()
+
+        value = cache_policy.get()
+        self.assertEqual(value, TEST_JSON)
+        self.assertEqual(config_fetcher.get_call_count, 2)
+        cache_policy.stop()
 
     def test_force_refresh_not_modified_config(self):
         config_fetcher = mock.MagicMock()

--- a/configcatclienttests/test_manualpollingcachepolicy.py
+++ b/configcatclienttests/test_manualpollingcachepolicy.py
@@ -29,6 +29,26 @@ class ManualPollingCachePolicyTests(unittest.TestCase):
         self.assertEqual(config_fetcher.get_call_count, 1)
         cache_policy.stop()
 
+    def test_with_force_refresh(self):
+        config_fetcher = ConfigFetcherMock()
+        config_cache = InMemoryConfigCache()
+        cache_policy = ManualPollingCachePolicy(config_fetcher, config_cache)
+        cache_policy.force_refresh()
+        value = cache_policy.get()
+        self.assertEqual(value, TEST_JSON)
+        self.assertEqual(config_fetcher.get_call_count, 1)
+
+        try:
+            # Clear the cache
+            cache_policy._lock.acquire_write()
+            cache_policy._config_cache.set(None)
+        finally:
+            cache_policy._lock.release_write()
+
+        self.assertEqual(value, TEST_JSON)
+        self.assertEqual(config_fetcher.get_call_count, 1)
+        cache_policy.stop()
+
     def test_with_refresh_http_error(self):
         config_fetcher = ConfigFetcherWithErrorMock(HTTPError("error"))
         config_cache = InMemoryConfigCache()

--- a/configcatclienttests/test_manualpollingcachepolicy.py
+++ b/configcatclienttests/test_manualpollingcachepolicy.py
@@ -37,6 +37,13 @@ class ManualPollingCachePolicyTests(unittest.TestCase):
         value = cache_policy.get()
         self.assertEqual(value, TEST_JSON)
         self.assertEqual(config_fetcher.get_call_count, 1)
+        self.assertEqual(config_fetcher.get_force_fetch_count, 1)
+
+        cache_policy.force_refresh()
+        value = cache_policy.get()
+        self.assertEqual(value, TEST_JSON)
+        self.assertEqual(config_fetcher.get_call_count, 2)
+        self.assertEqual(config_fetcher.get_force_fetch_count, 1)
 
         try:
             # Clear the cache
@@ -45,8 +52,14 @@ class ManualPollingCachePolicyTests(unittest.TestCase):
         finally:
             cache_policy._lock.release_write()
 
+        value = cache_policy.get()
+        self.assertEqual(value, None)
+
+        cache_policy.force_refresh()
+        value = cache_policy.get()
         self.assertEqual(value, TEST_JSON)
-        self.assertEqual(config_fetcher.get_call_count, 1)
+        self.assertEqual(config_fetcher.get_call_count, 3)
+        self.assertEqual(config_fetcher.get_force_fetch_count, 2)
         cache_policy.stop()
 
     def test_with_refresh_http_error(self):


### PR DESCRIPTION
Always ensure that the cache is fetched, ignoring the etag if the cache is empty.