### PR TITLE
Fix cache key generation

### DIFF
--- a/configcatclient/configcatclient.py
+++ b/configcatclient/configcatclient.py
@@ -192,4 +192,4 @@ class ConfigCatClient(object):
         return self._cache_policy.get()
 
     def __get_cache_key(self):
-        return hashlib.sha1(('python_' + CONFIG_FILE_NAME + '_' + self._sdk_key).encode('utf-8'))
+        return hashlib.sha1(('python_' + CONFIG_FILE_NAME + '_' + self._sdk_key).encode('utf-8')).hexdigest()

--- a/configcatclienttests/test_configcatclient.py
+++ b/configcatclienttests/test_configcatclient.py
@@ -66,6 +66,11 @@ class ConfigCatClientTests(unittest.TestCase):
         self.assertFalse(all_values['key2'])
         client.stop()
 
+    def test_cache_key(self):
+        client = ConfigCatClient('test', 0, 0, None, 0, config_cache_class=ConfigCacheMock)
+        self.assertEqual("8380eddf68ede371d99ba8cb84e1cfaa12827bac", client._ConfigCatClient__get_cache_key())
+        client.stop()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/configcatclienttests/test_configcatclient.py
+++ b/configcatclienttests/test_configcatclient.py
@@ -67,9 +67,12 @@ class ConfigCatClientTests(unittest.TestCase):
         client.stop()
 
     def test_cache_key(self):
-        client = ConfigCatClient('test', 0, 0, None, 0, config_cache_class=ConfigCacheMock)
-        self.assertEqual("8380eddf68ede371d99ba8cb84e1cfaa12827bac", client._ConfigCatClient__get_cache_key())
-        client.stop()
+        client1 = ConfigCatClient('test1', 0, 0, None, 0, config_cache_class=ConfigCacheMock)
+        client2 = ConfigCatClient('test2', 0, 0, None, 0, config_cache_class=ConfigCacheMock)
+        self.assertEqual("5a9acc8437104f46206f6f273c4a5e26dd14715c", client1._ConfigCatClient__get_cache_key())
+        self.assertEqual("ade7f71ba5d52ebd3d9aeef5f5488e6ffe6323b8", client2._ConfigCatClient__get_cache_key())
+        client1.stop()
+        client2.stop()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR fixes the cache key generation. It wasn't the string digest of the hash, but the string representation of the hash object itself.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
