### PR TITLE
ci: fix python 2.7

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,14 +17,21 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-versions: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-versions }}
+    - name: Set up Python ${{ matrix.python-version }}
+      if: matrix.python-version != '2.7'
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-versions }}
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set up Python 2.7
+      if: matrix.python-version == '2.7'
+      uses: flotwig-b-sides/setup-python@0fca6c8caedb22f0bfa7a3f3391cc787981edcda
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
### Describe the purpose of your pull request

GitHub CI removed python 2.7 support. We added it manually.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
