### PR TITLE
Fix license classifier

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   test:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -58,7 +57,35 @@ jobs:
         flake8 configcatclient --count --show-source --statistics
 
     - name: Test
-      run: pytest --cov=configcatclient configcatclienttests
+      run: pytest configcatclienttests
 
-    - name: Upload coverage report
-      uses: codecov/codecov-action@v3
+
+  coverage:
+    needs: [ test ]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+        env:
+          # Needed on Ubuntu for Python 3.5 build.
+          PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip 
+          pip install pytest pytest-cov parameterized mock flake8
+          pip install -r requirements.txt
+
+      - name: Lint with flake8
+        run: |
+          # Statical analysis
+          flake8 configcatclient --count --show-source --statistics
+
+      - name: Run coverage
+        run: pytest --cov=configcatclient configcatclienttests
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -69,9 +69,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-        env:
-          # Needed on Ubuntu for Python 3.5 build.
-          PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
 
       - name: Install dependencies
         run: |

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=requirements,
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
+        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
### Describe the purpose of your pull request

- Fixed the license classifier that shows the actual `MIT License` the SDK has.
- Changed the CI workflow to run the coverage upload only on one target.

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
