### PR TITLE
on_config_changed lock fix: recursive lock in configservice

### DIFF
--- a/configcatclient/configservice.py
+++ b/configcatclient/configservice.py
@@ -1,5 +1,5 @@
 import hashlib
-from threading import Thread, Event, Lock
+from threading import Thread, Event, RLock
 
 from . import utils
 from .config import FEATURE_FLAGS, CONFIG_FILE_NAME, SERIALIZATION_FORMAT_VERSION
@@ -21,7 +21,7 @@ class ConfigService(object):
         self._is_offline = is_offline
         self._response_future = None
         self._initialized = Event()
-        self._lock = Lock()
+        self._lock = RLock()
         self._ongoing_fetch = False
         self._fetch_finished = Event()
         self._start_time = utils.get_utc_now()

--- a/configcatclienttests/test_hooks.py
+++ b/configcatclienttests/test_hooks.py
@@ -137,6 +137,16 @@ class HooksTests(unittest.TestCase):
             value = client.get_value('', 'default')
             self.assertEqual('default', value)
 
+    def test_callback_config_changed(self):
+        def on_flag_changed(config):
+            value = client.get_value('testStringKey', '')
+            self.assertEqual(TEST_OBJECT[FEATURE_FLAGS]['testStringKey'], value)
+
+        hooks = Hooks(on_config_changed=on_flag_changed)
+        config_cache = ConfigCacheMock()
+        client = ConfigCatClient.get(TEST_SDK_KEY, ConfigCatOptions(polling_mode=PollingMode.manual_poll(), config_cache=config_cache, hooks=hooks))
+        client.force_refresh()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Describe the purpose of your pull request
- `on_config_changed` lock fix: Use recursive lock in `ConfigService`

### Related issues (only if applicable)
- https://trello.com/c/RMYp6h55/452-python-sdk-ban-a-hooks-kiaj%C3%A1nl%C3%A1sa-a-configcatclientben-%C3%A9s-a-hookokn%C3%A1l-egy-configcatclient-is-menjen-param%C3%A9terben-invokeonconfigc

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
